### PR TITLE
fix initialization of Accuracy to work with new version of torchmetrics

### DIFF
--- a/hydra_lightning/tasks/example/modules/base_adv.py
+++ b/hydra_lightning/tasks/example/modules/base_adv.py
@@ -15,9 +15,10 @@ class BaseAdvModule(BaseModule):
     def initialize_model(self):
         self.cross_entropy_criterion = torch.nn.CrossEntropyLoss()
 
-        self.train_accuracy = Accuracy()
-        self.std_val_accuracy = Accuracy()
-        self.adv_val_accuracy = Accuracy()
+        cfg: DictConfig = self.hparams.model_config
+        self.train_accuracy = Accuracy(task='multiclass', num_classes=cfg.num_classes)
+        self.std_val_accuracy = Accuracy(task='multiclass', num_classes=cfg.num_classes)
+        self.adv_val_accuracy = Accuracy(task='multiclass', num_classes=cfg.num_classes)
 
     # for robby.input_transforms.PGD
     @staticmethod

--- a/hydra_lightning/tasks/example/modules/resnet_robust_train.py
+++ b/hydra_lightning/tasks/example/modules/resnet_robust_train.py
@@ -14,9 +14,9 @@ class ResnetRobustTrainModule(BaseAdvModule):
     def initialize_model(self):
         super().initialize_model()
 
-        self.adv_train_accuracy = Accuracy()
-
         cfg: DictConfig = self.hparams.model_config
+        self.adv_train_accuracy = Accuracy(task='multiclass', num_classes=cfg.num_classes)
+
         self.backbone, num_features = get_robust_backbone(cfg.arch, cfg.eps)
         self.head = nn.Linear(num_features, cfg.num_classes)
 


### PR DESCRIPTION
New version of: https://torchmetrics.readthedocs.io/en/stable/classification/accuracy.html?highlight=Accuracy has required argument `task`.